### PR TITLE
Add dockerfile for combined py r image

### DIFF
--- a/531/py-r/Dockerfile
+++ b/531/py-r/Dockerfile
@@ -1,0 +1,56 @@
+FROM jupyter/minimal-notebook:2023-10-20
+
+ENV XDG_DATA_HOME=/tmp/local/share
+ENV XDG_CACHE_HOME=/tmp/cache
+ENV XDG_CONFIG_HOME=/tmp/config
+ENV JUPYTER_RUNTIME_DIR /tmp/runtime
+ENV JUPYTER_ALLOW_INSECURE_WRITES true
+ENV JUPYTER_CONFIG_DIR=/tmp/jupyter_config
+ENV NPM_CONFIG_CACHE=/tmp/npm
+ENV NO_UPDATE_NOTIFIER=true
+ENV IPYTHONDIR=/tmp/ipython
+ENV YARN_CACHE_FOLDER=/tmp/yarn_cache
+
+USER root
+# Install dependencies and various libraries
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Suppress the opt-in dialog for announcements.  
+# https://stackoverflow.com/questions/75511508/how-to-stop-this-message-would-you-like-to-receive-official-jupyter-news
+RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
+RUN mamba install --yes \
+    'altair-all' \
+    'vega_datasets' \
+    'otter-grader' \
+    'r-base>=4.1' \
+    'r-essentials' \
+    'r-devtools' \
+    'r-gert' \
+    'r-usethis' \
+    'r-testthat' \
+    'r-startup' \
+    'r-rmarkdown' \
+    'r-stringi' \
+    'r-tidyverse' \
+    'r-hmisc' \
+    'r-rjson' \
+    'r-ggally' \
+    'r-ggthemes' \
+    'r-cowplot' \
+    'r-irkernel' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# This seems to be needed for Jupyterlab to get the anywidget extension installed
+# although the package is technically already installed as part of altair-all.
+# This package is needed to show altair charts offline, such as in CBTF.
+# Each notebook need to start with `alt.renderers.enable('jupyter', offline=True)`
+RUN python -m pip install anywidget
+RUN pip3 cache purge
+
+COPY jupyter_server_config.py /etc/jupyter/
+
+USER jovyan
+CMD ["start.sh", "jupyter", "lab"]

--- a/531/py-r/jupyter_server_config.py
+++ b/531/py-r/jupyter_server_config.py
@@ -1,0 +1,32 @@
+import os
+
+c = get_config()  # type: ignore # noqa F821
+
+c.ServerApp.base_url = "/"
+if "WORKSPACE_BASE_URL" in os.environ:
+    c.NotebookApp.base_url = os.environ["WORKSPACE_BASE_URL"]
+
+c.ServerApp.port = 8080
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.open_browser = False
+c.ServerApp.password = ""
+c.ServerApp.token = ""
+c.ServerApp.allow_origin = "*"
+
+# RTC appears to be broken in the current version of `jupyter-collaboration`:
+# https://github.com/jupyterlab/jupyter-collaboration/issues/162
+# This opt-in will only be useful once the underlying issue is resolved.
+enable_rtc = bool(os.environ.get("ENABLE_REAL_TIME_COLLABORATION", False))
+c.YDocExtension.disable_rtc = not enable_rtc
+
+# `LAUNCH_FILE_NAME` can be set to open a specific file when the workspace is opened.
+if "LAUNCH_FILE_NAME" in os.environ:
+    # The "RTC" drive needs to be used if real-time collaboration is enabled.
+    # This isn't documented, but is discussed in these issues:
+    # https://github.com/jupyterlab/jupyter-collaboration/issues/202
+    # https://github.com/jupyterlab/jupyter-collaboration/issues/183
+    drive = "RTC:" if enable_rtc else ""
+    c.LabApp.default_url= f"/lab/tree/{drive}{os.environ['LAUNCH_FILE_NAME']}"
+
+c.FileContentsManager.delete_to_trash = False
+c.FileCheckpoints.checkpoint_dir = "/tmp/ipynb_checkpoints"


### PR DESCRIPTION
@ZacWarham This image uses both python and R via jupyterlab. I chose to build directly from the jupyter minimal notebook image because of the issues with PL not using their jlab base image https://github.com/PrairieLearn/PrairieLearn/issues/10719. I use conda/mamba to install both R and Py in this image and it's faster than installing R packages from scratch.

I haven't deleted any of the previous image files, because I see that you are doing the hack with manually setting the user to `1001`. I'm guessing we will have to do that here to for the images to work on the server, but for now I'm using it for local development where this works. If the PR looks good to you we can merge and I can try on the US server as well.

Long term, maybe having a combined py / r image like this for jupyterlab could be used as the base for multiple courses, which would be easier for maintenance? I guess that is partly what you are doing by setting up the base images already, but I thought there were quite some specific config in the course files although it seemed unrelated to the course itself, like the setting of user e.g.